### PR TITLE
4/9/15 Changes

### DIFF
--- a/data/areas/start
+++ b/data/areas/start
@@ -1,10 +1,23 @@
 <?xml version="1.0" ?>
 <zone name="Start" flags="0" creation="1427853343" opened="0" resetmsg="With a pop, the area resets around you." resetfreq="240" expbonus="0" goldbonus="0" minvnum="1" maxvnum="100">
-    <vobjes />
+    <vobjes>
+        <staticobj short="" plural="">
+            <BaseObject name="A blank object" desc="You see nothing special." script="" onum="0">
+                <components />
+                <aliases />
+                <properties>
+                    <property name="root">
+                        <variable type="0" value="0" />
+                    </property>
+                </properties>
+            </BaseObject>
+            <components />
+        </staticobj>
+    </vobjes>
     <rooms>
         <room rflag="0" x="0" y="0" z="0">
             <objc>
-                <BaseObject name="A blank room" desc="You see nothing special." script="" onum="1">
+                <BaseObject name="The Staff Lounge" desc="You see nothing special." script="" onum="1">
                     <components />
                     <aliases />
                     <properties>

--- a/data/players/Negasi
+++ b/data/players/Negasi
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
-<player title="the brave" prompt="&gt;" rank="1610612782" pflag="0">
+<player title="the brave" prompt="&gt;&gt;" rank="1610612782" pflag="0">
     <password value="1a68bc1a8f28aa786fbb89fd78abbb8ccdb5a307f3a8c4c30727830b8d2833" invalid="0" />
-    <timeinfo firstLogin="1427853848" onlineTime="5781" lastLogin="1427860204" />
+    <timeinfo firstLogin="1427853848" onlineTime="50313" lastLogin="1428434240" />
     <options>
         <option name="syslog">
             <variable type="2" value="1" />

--- a/src/com_builder.cpp
+++ b/src/com_builder.cpp
@@ -30,6 +30,7 @@ void InitializeBuilderCommands()
     world->commands.AddCommand(new CMDAddComponent());
     world->commands.AddCommand(new CMDGoto());
     world->commands.AddCommand(new CMDZcreate());
+	world->commands.AddCommand(new CMDAStats());
 }
 
 //zlist
@@ -37,6 +38,7 @@ CMDZlist::CMDZlist()
 {
     SetAccess(RANK_BUILDER);
     SetName("zlist");
+	SetType(CommandType::Builder);
 }
 void CMDZlist::Syntax(Player* mobile, int subcmd) const
 {
@@ -58,7 +60,7 @@ BOOL CMDZlist::Execute(const std::string &verb, Player* mobile,std::vector<std::
         {
             for (auto it: zones)
                 {
-                    st << (it->GetName()) << "\n";
+                    st << (it->GetName()) << " (" << it->GetMinVnum() << "-" << it->GetMaxVnum() << ")" << "\n";
                 }
         }
 
@@ -71,6 +73,7 @@ CMDRlist::CMDRlist()
 {
     SetName("rlist");
     SetAccess(RANK_BUILDER);
+	SetType(CommandType::Builder);
 }
 void CMDRlist::Syntax(Player* mobile, int subcmd) const
 {
@@ -115,6 +118,7 @@ CMDDig::CMDDig()
 {
     SetName("dig");
     SetAccess(RANK_BUILDER);
+	SetType(CommandType::Builder);
 }
 void CMDDig::Syntax(Player* mobile, int subcmd) const
 {
@@ -275,7 +279,9 @@ BOOL CMDDig::Execute(const std::string &verb, Player* mobile,std::vector<std::st
 CMDAStats::CMDAStats()
 {
     SetName("astat");
+	AddAlias("zstat");
     SetAccess(RANK_BUILDER);
+	SetType(CommandType::Builder);
 }
 BOOL CMDAStats::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -294,7 +300,7 @@ BOOL CMDAStats::Execute(const std::string &verb, Player* mobile,std::vector<std:
                     mobile->Message(MSG_ERROR, "Your location does not have a zone attached.");
                     return false;
                 }
-            mobile->Message(MSG_INFO, Stats(mobile, area));
+            mobile->Message(MSG_LIST, Stats(mobile, area));
             return true;
         }
     return true;
@@ -304,13 +310,15 @@ std::string CMDAStats::Stats(Player* mobile, Zone* area)
     std::stringstream st;
     st << area->GetName() << std::endl;
     st << Repeat('-', 80) << std::endl;
-    return st.str();
+	st << "Range: " << "Minimum Vnum: " << area->GetMinVnum() << " Maximum Vnum: " << area->GetMaxVnum() << std::endl;
+	return st.str();
 }
 
 CMDVCreate::CMDVCreate()
 {
     SetAccess(RANK_BUILDER);
-    SetName("vcreate");
+	SetName("vcreate"); 
+	SetType(CommandType::Builder);
 }
 BOOL CMDVCreate::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -345,6 +353,7 @@ BOOL CMDVCreate::Execute(const std::string &verb, Player* mobile,std::vector<std
 
     st << "Created static object " << vobj->GetOnum() << ".";
     mobile->Message(MSG_INFO, st.str());
+	zone->SaveZone();
     return true;
 }
 
@@ -352,6 +361,7 @@ CMDVList::CMDVList()
 {
     SetAccess(RANK_BUILDER);
     SetName("vlist");
+	SetType(CommandType::Builder);
 }
 BOOL CMDVList::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -391,7 +401,7 @@ BOOL CMDVList::Execute(const std::string &verb, Player* mobile,std::vector<std::
         }
 
     itEnd = objects.end();
-    st << left << setw(10) << "vnum" << right << "name" << endl;
+	st << left << setw(10) << "vnum" << right << "name" << Repeat(" ", 20) << "Zone: " << zone->GetName() << endl;
     st << Repeat('-', 80) << endl;
     for (it = objects.begin(); it != itEnd; ++it)
         {
@@ -407,6 +417,7 @@ CMDMCreate::CMDMCreate()
 {
     SetAccess(RANK_BUILDER);
     SetName("mcreate");
+	SetType(CommandType::Builder);
 }
 BOOL CMDMCreate::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -448,6 +459,7 @@ CMDMList::CMDMList()
 {
     SetAccess(RANK_BUILDER);
     SetName("mlist");
+	SetType(CommandType::Builder);
 }
 BOOL CMDMList::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -502,6 +514,7 @@ CMDMLoad::CMDMLoad()
 {
     SetName("mload");
     SetAccess(RANK_BUILDER);
+	SetType(CommandType::Builder);
 }
 BOOL CMDMLoad::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -556,6 +569,7 @@ CMDAddComponent::CMDAddComponent()
     SetName("addcomponent");
     AddAlias("adc");
     SetAccess(RANK_BUILDER);
+	SetType(CommandType::Builder);
 }
 BOOL CMDAddComponent::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -637,6 +651,7 @@ CMDGoto::CMDGoto()
 {
     SetName("goto");
     SetAccess(RANK_BUILDER);
+	SetType(CommandType::Builder);
 }
 BOOL CMDGoto::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -675,6 +690,7 @@ CMDZcreate::CMDZcreate()
 {
     SetName("zcreate");
     SetAccess(RANK_BUILDER);
+	SetType(CommandType::Builder);
 }
 BOOL CMDZcreate::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -702,7 +718,7 @@ BOOL CMDZcreate::Execute(const std::string &verb, Player* mobile,std::vector<std
             return false;
         }
 
-    if (world->GetZone(args[0]) == nullptr)
+    if (world->GetZone(args[0]) != nullptr)
         {
             mobile->Message(MSG_ERROR,"Error: zone with name already  exists.\n");
             return false;

--- a/src/com_builder.cpp
+++ b/src/com_builder.cpp
@@ -31,6 +31,7 @@ void InitializeBuilderCommands()
     world->commands.AddCommand(new CMDGoto());
     world->commands.AddCommand(new CMDZcreate());
 	world->commands.AddCommand(new CMDAStats());
+	world->commands.AddCommand(new CMDRcreate());
 }
 
 //zlist
@@ -746,4 +747,46 @@ BOOL CMDZcreate::Execute(const std::string &verb, Player* mobile,std::vector<std
     mobile->Message(MSG_INFO, st.str());
 
     return true;
+}
+
+CMDRcreate::CMDRcreate()
+{
+	SetAccess(RANK_BUILDER);
+	SetName("rcreate");
+	SetType(CommandType::Builder);
+}
+BOOL CMDRcreate::Execute(const std::string &verb, Player* mobile, std::vector<std::string> &args, int subcmd)
+{
+	Zone* zone = NULL;
+	ObjectContainer* location = NULL;
+	Room* room = NULL;
+	std::stringstream st;
+
+	location = mobile->GetLocation();
+	if (!location || !location->IsRoom())
+	{
+		mobile->Message(MSG_ERROR, "You are not in a room.");
+		return false;
+	}
+
+	zone = location->GetZone();
+	if (!zone)
+	{
+		mobile->Message(MSG_ERROR, "The room you are in does not have a zone.");
+		return false;
+	}
+
+	try
+	{
+		room = zone->AddRoom();
+	}
+	catch (std::runtime_error e)
+	{
+		mobile->Message(MSG_ERROR, e.what());
+		return false;
+	}
+
+	st << "Created Room " << room->GetOnum() << ".";
+	mobile->Message(MSG_INFO, st.str());
+	return true;
 }

--- a/src/com_builder.h
+++ b/src/com_builder.h
@@ -99,5 +99,11 @@ public:
     BOOL Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd);
 };
 
+class CMDRcreate :public Command
+{
+public:
+	CMDRcreate();
+	BOOL Execute(const std::string &verb, Player* mobile, std::vector<std::string> &args, int subcmd);
+};
 
 #endif

--- a/src/com_gen.cpp
+++ b/src/com_gen.cpp
@@ -46,6 +46,7 @@ void InitializeGenCommands()
 CMDQuit::CMDQuit()
 {
     SetName("quit");
+	SetType(CommandType::Misc);
 }
 BOOL CMDQuit::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -58,6 +59,7 @@ BOOL CMDQuit::Execute(const std::string &verb, Player* mobile,std::vector<std::s
 CMDSave::CMDSave()
 {
     SetName("save");
+	SetType(CommandType::Misc);
 }
 BOOL CMDSave::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -74,6 +76,7 @@ BOOL CMDSave::Execute(const std::string &verb, Player* mobile,std::vector<std::s
 CMDBackup::CMDBackup()
 {
     SetName("backup");
+	SetType(CommandType::Misc);
 }
 BOOL CMDBackup::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -106,6 +109,7 @@ CMDWho::CMDWho()
 {
     SetName("who");
     AddAlias("wh");
+	SetType(CommandType::Information);
 }
 BOOL CMDWho::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -141,6 +145,7 @@ CMDToggle::CMDToggle()
 {
     SetName("toggle");
     AddAlias("tog");
+	SetType(CommandType::Misc);
 }
 BOOL CMDToggle::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -210,6 +215,7 @@ CMDScore::CMDScore()
 {
     SetName("score");
     AddAlias("sc");
+	SetType(CommandType::Information);
 }
 BOOL CMDScore::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -237,6 +243,7 @@ CMDChan::CMDChan()
 {
     SetName("channels");
     AddAlias("chan");
+	SetType(CommandType::Communication);
 }
 BOOL CMDChan::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -259,6 +266,7 @@ BOOL CMDChan::Execute(const std::string &verb, Player* mobile,std::vector<std::s
 CMDCommands::CMDCommands()
 {
     SetName("commands");
+	SetType(CommandType::Information);
 }
 void CMDCommands::GetCommands(Player*mobile, std::vector<std::string>& names, CommandType filter)
 {
@@ -285,7 +293,7 @@ void CMDCommands::Syntax(Player* mobile, int subcmd) const
         {
             st << "god|";
         }
-    st << "information|object|movement|communication|all].";
+    st << "information|object|movement|communication]";
 
     mobile->Message(MSG_INFO, st.str());
 }
@@ -293,12 +301,77 @@ BOOL CMDCommands::Execute(const std::string &verb, Player* mobile,std::vector<st
 {
     std::vector <std::string> commands;
     std::vector<std::string> headers;
+	std::stringstream all, info, move, comm, misc, builder, admin, god, object, socials;
     int count = 0;
 
-    if (!args.size())
-        {
-            Syntax(mobile, subcmd);
-            return false;
+	if (!args.size())
+	{
+		if (mobile->HasAccess(RANK_GOD))
+		{
+			commands.clear();
+			god << Center("[Master Commands]", 80) << "\r\n\n";
+			GetCommands(mobile, commands, CommandType::God);
+			god << CenterLines(Explode(commands),80) << "\r\n\n";
+			commands.clear();
+		}
+		if (mobile->HasAccess(RANK_ADMIN))
+		{
+			admin << Center("[Administrative Commands]",80) << "\r\n\n";
+			GetCommands(mobile, commands, CommandType::Admin);
+			admin << CenterLines(Explode(commands), 80) << "\r\n\n";
+			commands.clear();
+		}
+		if (mobile->HasAccess(RANK_BUILDER))
+		{
+			builder << Center("[Builder Commands]", 80) << "\r\n\n";
+			GetCommands(mobile, commands, CommandType::Builder);
+			builder << CenterLines(Explode(commands),80) << "\r\n\n";
+			commands.clear();	
+		}
+
+		info << Center("[Information Commands]",80) << "\r\n\n";
+		GetCommands(mobile, commands, CommandType::Information);
+		info << CenterLines(Explode(commands),80) << "\r\n\n";
+		commands.clear();
+
+		move << Center("[Movement Commands]",80) << "\r\n\n";
+		GetCommands(mobile, commands, CommandType::Movement);
+		move << CenterLines(Explode(commands), 80) << "\r\n\n";
+		commands.clear();
+
+		comm << Center("[Communication Commands]",80) << "\r\n\n";
+		GetCommands(mobile, commands, CommandType::Communication);
+		GetCommands(mobile, commands, CommandType::Channel);
+		comm << CenterLines(Explode(commands), 80) << "\r\n\n";
+		commands.clear();
+
+		misc << Center("[Miscellaneous Commands]",80) << "\r\n\n";
+		GetCommands(mobile, commands, CommandType::Misc);
+		misc << CenterLines(Explode(commands),80) << "\r\n\n";
+		commands.clear();
+
+
+		GetCommands(mobile, commands, CommandType::Object);
+		if (!commands.empty())
+		{
+			object << Center("[Object Commands]",80) << "\r\n\n";
+			object << CenterLines(Explode(commands), 80) << "\r\n\n";
+			commands.clear();
+		}
+		commands.clear();
+
+		GetCommands(mobile, commands, CommandType::Social);
+		if (!commands.empty())
+		{
+			socials << Center("[Socials]", 80) << "\r\n\n";
+			socials << CenterLines(Explode(commands), 80) << "\r\n\n";
+			commands.clear();
+		}
+		commands.clear();
+
+			all << god.str() << admin.str() << builder.str() << info.str() << move.str() << comm.str() << misc.str() << object.str() << socials.str();
+			mobile->Message(MSG_LIST, all.str());
+			return true;
         }
 
     if (args[0] == "god")
@@ -362,10 +435,6 @@ BOOL CMDCommands::Execute(const std::string &verb, Player* mobile,std::vector<st
             GetCommands(mobile, commands, CommandType::Channel);
             GetCommands(mobile, commands, CommandType::Communication);
         }
-    else if (args[0] == "all")
-        {
-            GetCommands(mobile, commands, CommandType::All);
-        }
     else
         {
             Syntax(mobile, subcmd);
@@ -402,6 +471,7 @@ CMDHist::CMDHist()
 {
     SetName("history");
     AddAlias("hist");
+	SetType(CommandType::Information);
 }
 BOOL CMDHist::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -446,6 +516,7 @@ BOOL CMDHist::Execute(const std::string &verb, Player* mobile,std::vector<std::s
 CMDUptime::CMDUptime()
 {
     SetName("uptime");
+	SetType(CommandType::Information);
 }
 BOOL CMDUptime::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -471,6 +542,7 @@ CMDWhois::CMDWhois()
 {
     SetName("whois");
     AddAlias("finger");
+	SetType(CommandType::Information);
 }
 BOOL CMDWhois::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -529,6 +601,7 @@ CMDLook::CMDLook()
 {
     SetName("look");
     AddAlias("l");
+	SetType(CommandType::Information);
 }
 BOOL CMDLook::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -560,6 +633,7 @@ CMDCoord::CMDCoord()
 {
     SetName("coord");
     AddAlias("coords");
+	SetType(CommandType::Information);
 }
 BOOL CMDCoord::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -582,6 +656,7 @@ BOOL CMDCoord::Execute(const std::string &verb, Player* mobile,std::vector<std::
 CMDSuicide::CMDSuicide()
 {
     SetName("suicide");
+	SetType(CommandType::Misc);
 }
 BOOL CMDSuicide::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -610,6 +685,7 @@ void CMDSuicide::Confirm(Socket* sock, BOOL choice)
 CMDSay::CMDSay()
 {
     SetName("say");
+	SetType(CommandType::Communication);
 }
 BOOL CMDSay::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -628,6 +704,7 @@ BOOL CMDSay::Execute(const std::string &verb, Player* mobile,std::vector<std::st
 CMDEmote::CMDEmote()
 {
     SetName("emote");
+	SetType(CommandType::Communication);
 }
 BOOL CMDEmote::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -645,6 +722,7 @@ BOOL CMDEmote::Execute(const std::string &verb, Player* mobile,std::vector<std::
 CMDPrompt::CMDPrompt()
 {
     SetName("prompt");
+	SetType(CommandType::Misc);
 }
 BOOL CMDPrompt::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -663,6 +741,7 @@ BOOL CMDPrompt::Execute(const std::string &verb, Player* mobile,std::vector<std:
 CMDSockstats::CMDSockstats()
 {
     SetName("sockstats");
+	SetType(CommandType::Information);
 }
 BOOL CMDSockstats::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -697,6 +776,7 @@ BOOL CMDSockstats::Execute(const std::string &verb, Player* mobile,std::vector<s
 CMDExits::CMDExits()
 {
     SetName("exits");
+	SetType(CommandType::Movement);
 }
 BOOL CMDExits::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args, int subcmd)
 {

--- a/src/com_movement.cpp
+++ b/src/com_movement.cpp
@@ -71,6 +71,7 @@ CMDNorth::CMDNorth()
     SetName("north");
     AddAlias("n");
     SetSubcmd(DIR_NORTH);
+	SetType(CommandType::Movement);
 }
 BOOL CMDNorth::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -82,6 +83,7 @@ CMDSouth::CMDSouth()
     SetName("south");
     AddAlias("s");
     SetSubcmd(DIR_SOUTH);
+	SetType(CommandType::Movement);
 }
 BOOL CMDSouth::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -93,6 +95,7 @@ CMDEast::CMDEast()
     SetName("east");
     AddAlias("e");
     SetSubcmd(DIR_EAST);
+	SetType(CommandType::Movement);
 }
 BOOL CMDEast::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -104,6 +107,7 @@ CMDWest::CMDWest()
     SetName("west");
     AddAlias("w");
     SetSubcmd(DIR_WEST);
+	SetType(CommandType::Movement);
 }
 BOOL CMDWest::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -115,6 +119,7 @@ CMDNortheast::CMDNortheast()
     SetName("northeast");
     AddAlias("ne");
     SetSubcmd(DIR_NORTHEAST);
+	SetType(CommandType::Movement);
 }
 BOOL CMDNortheast::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -126,6 +131,7 @@ CMDSoutheast::CMDSoutheast()
     SetName("southeast");
     AddAlias("se");
     SetSubcmd(DIR_SOUTHEAST);
+	SetType(CommandType::Movement);
 }
 BOOL CMDSoutheast::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -137,6 +143,7 @@ CMDSouthwest::CMDSouthwest()
     SetName("southwest");
     AddAlias("sw");
     SetSubcmd(DIR_SOUTHWEST);
+	SetType(CommandType::Movement);
 }
 BOOL CMDSouthwest::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -148,6 +155,7 @@ CMDNorthwest::CMDNorthwest()
     SetName("northwest");
     AddAlias("nw");
     SetSubcmd(DIR_NORTHWEST);
+	SetType(CommandType::Movement);
 }
 BOOL CMDNorthwest::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -159,6 +167,7 @@ CMDUp::CMDUp()
     SetName("up");
     AddAlias("u");
     SetSubcmd(DIR_UP);
+	SetType(CommandType::Movement);
 }
 BOOL CMDUp::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -170,6 +179,7 @@ CMDDown::CMDDown()
     SetName("down");
     AddAlias("d");
     SetSubcmd(DIR_DOWN);
+	SetType(CommandType::Movement);
 }
 BOOL CMDDown::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {

--- a/src/com_wiz.cpp
+++ b/src/com_wiz.cpp
@@ -33,6 +33,7 @@ CMDCopyover::CMDCopyover()
 {
     SetName("copyover");
     SetAccess(RANK_GOD);
+	SetType(CommandType::God);
 }
 BOOL CMDCopyover::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -46,6 +47,7 @@ CMDMkgod::CMDMkgod()
 {
     SetName("mkgod");
     SetAccess(RANK_GOD);
+	SetType(CommandType::God);
 }
 BOOL CMDMkgod::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -86,6 +88,7 @@ CMDMkbuilder::CMDMkbuilder()
 {
     SetName("mkbuilder");
     SetAccess(RANK_GOD);
+	SetType(CommandType::God);
 }
 BOOL CMDMkbuilder::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -125,7 +128,8 @@ BOOL CMDMkbuilder::Execute(const std::string &verb, Player* mobile,std::vector<s
 CMDShutdown::CMDShutdown()
 {
     SetName("shutdown");
-    SetAccess(RANK_ADMIN);
+    SetAccess(RANK_GOD);
+	SetType(CommandType::God);
 }
 BOOL CMDShutdown::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -138,6 +142,7 @@ CMDBan::CMDBan()
 {
     SetName("ban");
     SetAccess(RANK_ADMIN);
+	SetType(CommandType::Admin);
 }
 BOOL CMDBan::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -181,6 +186,7 @@ CMDSilence::CMDSilence()
 {
     SetName("silence");
     SetAccess(RANK_ADMIN);
+	SetType(CommandType::Admin);
 }
 BOOL CMDSilence::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -224,6 +230,7 @@ CMDUnsilence::CMDUnsilence()
 {
     SetName("unsilence");
     SetAccess(RANK_ADMIN);
+	SetType(CommandType::Admin);
 }
 BOOL CMDUnsilence::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -262,6 +269,7 @@ CMDDisconnect::CMDDisconnect()
 {
     SetName("disconnect");
     SetAccess(RANK_ADMIN);
+	SetType(CommandType::Admin);
 }
 BOOL CMDDisconnect::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -301,6 +309,7 @@ CMDEcho::CMDEcho()
 {
     SetName("echo");
     SetAccess(RANK_ADMIN);
+	SetType(CommandType::Admin);
 }
 BOOL CMDEcho::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -330,6 +339,7 @@ CMDPdelete::CMDPdelete()
 {
     SetName("pdelete");
     SetAccess(RANK_ADMIN);
+	SetType(CommandType::Admin);
 }
 BOOL CMDPdelete::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -349,6 +359,7 @@ CMDSstatus::CMDSstatus()
     SetName("sstatus");
     AddAlias("sstat");
     SetAccess(RANK_ADMIN);
+	SetType(CommandType::Admin);
 }
 BOOL CMDSstatus::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -391,6 +402,7 @@ CMDForce::CMDForce()
 {
     SetName("force");
     SetAccess(RANK_ADMIN);
+	SetType(CommandType::Admin);
 }
 BOOL CMDForce::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args,int subcmd)
 {
@@ -416,7 +428,7 @@ BOOL CMDForce::Execute(const std::string &verb, Player* mobile,std::vector<std::
             mobile->Message(MSG_ERROR, "That player was not found.");
             return false;
         }
-    if (BitIsSet(target->GetRank(),RANK_GOD))
+    if (BitIsSet(target->GetRank(),RANK_GOD) || (BitIsSet(mobile->GetRank(), RANK_ADMIN) && BitIsSet(target->GetRank(), RANK_ADMIN)))
         {
             mobile->Message(MSG_ERROR, "You probably shouldn't try to do that...");
             return false;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1,5 +1,8 @@
 #include "npc.h"
-
+#include "olc.h"
+#include "olcGroup.h"
+#include "world.h"
+#include "olcManager.h"
 Npc::Npc()
 {
 }
@@ -23,4 +26,15 @@ BOOL Npc::IsNpc() const
 void Npc::Copy(BaseObject* obj) const
 {
     BaseObject::Copy(obj);
+}
+
+BOOL InitializeNPCOlcs()
+{
+	World* world = World::GetPtr();
+	OlcManager* omanager = world->GetOlcManager();
+	OlcGroup* ngroup = new OlcGroup();
+
+	ngroup->SetInheritance(omanager->GetGroup(OLCGROUP::Entity));
+	omanager->AddGroup(OLCGROUP::NPC, ngroup);
+	return true;
 }

--- a/src/npc.h
+++ b/src/npc.h
@@ -17,4 +17,5 @@ public:
     BOOL IsNpc() const;
     virtual void Copy(BaseObject* obj) const;
 };
+BOOL InitializeNPCOlcs();
 #endif

--- a/src/olc.cpp
+++ b/src/olc.cpp
@@ -115,11 +115,8 @@ bool ParseVnum(Player* mobile, std::string& arg, VNUM & num, std::string& comp, 
     if (dotpos == std::string::npos) //no component found
         {
 //check if we're parsing a room vnum and whether or not "here" was used.
-            if (inroom && arg == "here")
-                {
-                    num = mobile->GetLocation()->GetOnum();
-                    return true;
-                }
+           
+ 
 //this has to be a vnum:
             try
                 {
@@ -127,9 +124,15 @@ bool ParseVnum(Player* mobile, std::string& arg, VNUM & num, std::string& comp, 
                     return true;
                 }
             catch (std::bad_cast e)
-                {
+			{
+				if (inroom)
+				{
+					num = mobile->GetLocation()->GetOnum();
+					return true;
+				}
+				
                     return false;
-                }
+            }
         }
 
 //there was a component attached.
@@ -181,39 +184,64 @@ bool HandleEntry(Player* mobile, BaseObject* obj, OlcGroup* group, std::vector<s
     std::string value;
     std::vector<std::string>::iterator it;
 
-    if (args.size() == 1) //we only have object/object.component, show entries.
-        {
-            ShowGroup(mobile, group);
-            return true;
-        }
-
-    name = args[1];
-    entry = group->GetEntry(name);
+	if (isnum(args[0].c_str()))
+	{
+		if (args.size() == 1) //we only have object/object.component, show entries.
+		{
+			ShowGroup(mobile, group);
+			return true;
+		}
+	}
+	else if (args.empty())
+	{
+		ShowGroup(mobile, group);
+	}
+	
+	if (!isnum(args[0].c_str()) && group->GetEntry(args[0]) != nullptr)
+	{
+		name = args[0];
+		entry = group->GetEntry(name);
+	}
+	else if (isnum(args[0].c_str()) && group->GetEntry(args[0]) == nullptr)
+	{
+		name = args[1];
+		entry = group->GetEntry(name);
+	}
     if (entry == nullptr)
         {
             mobile->Message(MSG_ERROR, "That entry does not exist.");
             return false;
         }
 
-    if (args.size() == 2) //we hope this is an editor. Otherwise it fails.
-        {
+    //if (args.size() == 2) //we hope this is an editor. Otherwise it fails.
+      //  {
             if (entry->GetInputType() == OLCDT::EDITOR)
                 {
                     return DoEdit(mobile, obj, entry, "", OlcEditType::Room);
                 }
-            else
-                {
-                    mobile->Message(MSG_ERROR, "Invalid syntax.");
-                    return false;
-                }
-        }
+        //    else
+          //      {
+            //        mobile->Message(MSG_ERROR, "Invalid syntax.");
+              //      return false;
+               // }
+        //}
 
-    if (args.size() > 2) //we have input.
+    if (args.size() >= 2) //we have input.
         {
             it = args.begin();
-            advance(it, 2);
+			if (isnum(args[0].c_str()))
+			{
+				advance(it, 2);
+			}
+			else
+			{
+				advance(it, 1);
+			}
             value = Explode(args, it);
-            return DoEdit(mobile, obj, entry, value, OlcEditType::Room);
+            if( DoEdit(mobile, obj, entry, value, OlcEditType::Room) )
+			{
+				mobile->Message(MSG_INFO, "OK.");
+			}
         }
 
 //we should never get here.
@@ -224,6 +252,7 @@ CMDREdit::CMDREdit()
 {
     SetName("redit");
     SetAccess(RANK_BUILDER);
+	SetType(CommandType::Builder);
 }
 BOOL CMDREdit::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args, int subcmd)
 {
@@ -240,7 +269,7 @@ BOOL CMDREdit::Execute(const std::string &verb, Player* mobile,std::vector<std::
 
     if (args.size() == 0)
         {
-            mobile->Message(MSG_ERROR, "Syntax: redit <vnum>[.component] [field] [value].");
+            mobile->Message(MSG_ERROR, "Syntax: redit [<vnum>][.component] [field] [value].");
             return false;
         }
 
@@ -249,6 +278,7 @@ BOOL CMDREdit::Execute(const std::string &verb, Player* mobile,std::vector<std::
             mobile->Message(MSG_ERROR, "Invalid vnum.");
             return false;
         }
+	
     if (num < 1 || !zon->RoomExists(num))
         {
             mobile->Message(MSG_ERROR, "That vnum does not exist.");
@@ -306,6 +336,7 @@ CMDMEdit::CMDMEdit()
 {
     SetName("medit");
     SetAccess(RANK_BUILDER);
+	SetType(CommandType::Builder);
 }
 BOOL CMDMEdit::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args, int subcmd)
 {
@@ -388,6 +419,7 @@ CMDOEdit::CMDOEdit()
 {
     SetName("oedit");
     SetAccess(RANK_BUILDER);
+	SetType(CommandType::Builder);
 }
 BOOL CMDOEdit::Execute(const std::string &verb, Player* mobile,std::vector<std::string> &args, int subcmd)
 {

--- a/src/olcGroup.cpp
+++ b/src/olcGroup.cpp
@@ -18,6 +18,7 @@ OlcGroup::~OlcGroup()
     for (it = _entries.begin(); it != itEnd; ++it)
         {
             delete (*it);
+			(*it) = nullptr;
         }
 }
 
@@ -42,20 +43,21 @@ IOlcEntry* OlcGroup::GetEntry(const std::string& name)
 }
 void OlcGroup::ListEntries(std::vector<IOlcEntry*>* entries)
 {
-   /* if (_inherit)                  //We check if this OLCgroup is inheriting another. If so, we copy the entries from the inherited group.
-        {
-            _inherit->ListEntries(entries);
-        }*/
+    /* if (_inherit)                  //We check if this OLCgroup is inheriting another. If so, we copy the entries from the inherited group.
+         {
+             _inherit->ListEntries(entries);
+         }*/
 
     std::vector<IOlcEntry*>::iterator it, itEnd;
 
     itEnd = _entries.end();
     for (it = _entries.begin(); it != itEnd; ++it)
         {
-			entries->push_back((*it));
+            entries->push_back((*it));
 
         }
 }
+
 
 void OlcGroup::SetComponentName(const std::string& comp)
 {
@@ -71,8 +73,10 @@ OlcGroup* OlcGroup::GetInheritance()
     return _inherit;
 }
 void OlcGroup::SetInheritance(OlcGroup* inherit)
-{                                               // This recursively copies entries from the base OLCGroup (cont'd)
-	_inherit = inherit;                         // and from base OLCGroup's parent and so on until it (cont'd) 
-	inherit->ListEntries(&_entries);                     // reaches an OLCGroup with no inheritance.  
-	
+{
+	std::vector<IOlcEntry*> entries;              // This recursively copies entries from the base OLCGroup (cont'd)
+    _inherit = inherit;          
+	_inherit->ListEntries(&_entries);                                       // and from base OLCGroup's parent and so on until it (cont'd)
+                // reaches an OLCGroup with no inheritance.
+
 }

--- a/src/olcs.cpp
+++ b/src/olcs.cpp
@@ -5,6 +5,7 @@
 #include "room.h"
 #include "entity.h"
 #include "baseObject.h"
+#include "npc.h"
 
 BOOL InitializeOlcs()
 {
@@ -24,6 +25,9 @@ BOOL InitializeOlcs()
         {
             return false;
         }
-
+	if (!InitializeNPCOlcs())
+	{
+		return false;
+	}
     return true;
 }

--- a/src/playerManager.cpp
+++ b/src/playerManager.cpp
@@ -27,7 +27,7 @@ BOOL PlayerManager::AddPlayer(Player* player)
         {
             return false;
         }
-    if (player->GetSocket()->GetConnectionType() != ConnectionType::Game)
+    if (player->GetSocket()->GetConnectionType() != CON_Game)
         {
             return false;
         }
@@ -79,19 +79,23 @@ Player* PlayerManager::LoadPlayer(const std::string &name) const
 
 void PlayerManager::Shutdown()
 {
-    for (auto person: _users)
+    std::list<Player*>::iterator it, itEnd;
+
+	itEnd = _users.end();
+    for (it = _users.begin(); it != itEnd; ++it)
         {
-            person->Message(MSG_CRITICAL,"The mud is shutting down now. Your Character will be autosaved.");
-            person->Save(true);
-            person->GetSocket()->Kill();
+            (*it)->Message(MSG_CRITICAL,"The mud is shutting down now. Your Character will be autosaved.");
+            (*it)->Save(true);
+            (*it)->GetSocket()->Kill();
+            it = _users.begin();
         }
 }
 void PlayerManager::Update()
 {
-	if (_users.empty())
-	{
-		return;
-	}
+    if (_users.empty())
+        {
+            return;
+        }
 
     for (auto pit: _users)
         {

--- a/src/staticObject.cpp
+++ b/src/staticObject.cpp
@@ -22,19 +22,19 @@ StaticObject::~StaticObject()
 
 std::string StaticObject::GetShort() const
 {
-	return _short;
+    return _short;
 }
 void StaticObject::SetShort(const std::string &s)
 {
-	_short = s;
+    _short = s;
 }
 std::string StaticObject::GetPlural() const
 {
-	return _plural;
+    return _plural;
 }
 void StaticObject::SetPlural(const std::string &s)
 {
-	_plural = s;
+    _plural = s;
 }
 
 unsigned int StaticObject::GetTotalCount() const
@@ -128,8 +128,8 @@ void StaticObject::Serialize(TiXmlElement* root)
     TiXmlElement* obj = new TiXmlElement("staticobj");
     TiXmlElement* component = NULL;
     BaseObject::Serialize(obj);
-	obj->SetAttribute("short", _short.c_str());
-	obj->SetAttribute("plural", _plural.c_str());
+    obj->SetAttribute("short", _short.c_str());
+    obj->SetAttribute("plural", _plural.c_str());
     TiXmlElement* components = new TiXmlElement("components");
     itEnd = _components.end();
     for (it = _components.begin(); it != itEnd; ++it)
@@ -150,9 +150,12 @@ void StaticObject::Deserialize(TiXmlElement* root)
     TiXmlElement* components = NULL;
     IComponentMeta* com = NULL;
     std::string cname;
-	
-	_short = root->Attribute("short");
-	_plural = root->Attribute("plural");
+	// TiXmlElement* obj = new TiXmlElement("staticobj");
+
+	//BaseObject::Deserialize(obj);
+	BaseObject::Deserialize(root->FirstChild("BaseObject")->ToElement());
+    _short = root->Attribute("short");
+    _plural = root->Attribute("plural");
     node = root->FirstChild("components");
     if (node)
         {
@@ -174,13 +177,13 @@ BOOL InitializeStaticObjectOlcs()
     OlcManager* omanager = world->GetOlcManager();
     OlcGroup* sgroup = new OlcGroup();
 
-	sgroup->SetInheritance(omanager->GetGroup(OLCGROUP::BaseObject));
-	sgroup->AddEntry(new OlcStringEntry<StaticObject>("short", "the title of the object seen in rooms", OF_NORMAL, OLCDT::STRING,
-		std::bind(&StaticObject::GetShort, std::placeholders::_1),
-		std::bind(&StaticObject::SetShort, std::placeholders::_1, std::placeholders::_2)));
-	sgroup->AddEntry(new OlcStringEntry<StaticObject>("plural", "Sets the plural of the object", OF_NORMAL, OLCDT::STRING,
-		std::bind(&StaticObject::GetPlural, std::placeholders::_1),
-		std::bind(&StaticObject::SetPlural, std::placeholders::_1, std::placeholders::_2)));
+    sgroup->SetInheritance(omanager->GetGroup(OLCGROUP::BaseObject));
+    sgroup->AddEntry(new OlcStringEntry<StaticObject>("short", "the title of the object seen in rooms", OF_NORMAL, OLCDT::STRING,
+                     std::bind(&StaticObject::GetShort, std::placeholders::_1),
+                     std::bind(&StaticObject::SetShort, std::placeholders::_1, std::placeholders::_2)));
+    sgroup->AddEntry(new OlcStringEntry<StaticObject>("plural", "Sets the plural of the object", OF_NORMAL, OLCDT::STRING,
+                     std::bind(&StaticObject::GetPlural, std::placeholders::_1),
+                     std::bind(&StaticObject::SetPlural, std::placeholders::_1, std::placeholders::_2)));
     omanager->AddGroup(OLCGROUP::STATIC, sgroup);
     return true;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <ctime>
 #include <ctype.h>
+#include <cctype>
 #include <cstdlib>
 #include <cmath>
 #include <strings.h>
@@ -37,6 +38,19 @@ int tonum(const char* str)
     return ret;
 }
 
+bool isnum(const char* str)
+{
+	int num = 0;
+	try
+	{
+		num = tonum(str);
+	}
+	catch (std::bad_cast e)
+	{
+		return false;
+	}
+	return true;
+}
 BOOL FileExists(const std::string &name)
 {
     struct stat info;
@@ -328,6 +342,43 @@ std::string Center(const std::string &str,const int width)
     temp += Repeat(" ", right);
 
     return temp;
+}
+
+std::string CenterLines(const std::string &str, const int width)
+{
+	const char *blankspace = " ";
+	std::string lines,temp, temp1;
+	int leftfiller;
+	int totalfiller;
+	
+	lines = str;
+	if (str.empty())
+	{
+		return str;
+	}
+
+	if ((int)str.length() < (width - (int)str.length()))
+	{
+		return Center(str, width);
+	}
+	std::string::iterator it = lines.begin() , itEnd = lines.end();
+	for (; it != itEnd; ++it)
+		{
+			temp1 += (*it);
+			if ( ((int)temp1.length()) >= width - ((int)temp1.length()) && (*it) == *blankspace)
+			{
+					temp += Center(temp1, width);
+					totalfiller = ((width - (int)temp1.length()) / 2);
+					leftfiller = (totalfiller / 2 ? totalfiller - 1 : totalfiller);
+					temp1.clear();
+
+					continue;
+		    }
+			
+	    }
+	temp += Repeat(" ", leftfiller);
+	temp += temp1;
+		return temp;
 }
 
 std::string Explode(std::vector <std::string> &parts, const std::string &del)

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,6 +11,7 @@
 
 //misc
 int tonum(const char* str);
+bool isnum(const char* str);
 BOOL FileExists(const std::string &name);
 /*
 *Checks to see if a directory exists.
@@ -65,6 +66,7 @@ std::string Capitalize(const std::string &str);
 std::string Repeat(const std::string &filler,const int count);
 std::string Repeat(const char filler, const int count);
 std::string Center(const std::string &str,const int width);
+std::string CenterLines(const std::string &str, const int width);
 std::string Explode(std::vector <std::string> &parts, const std::string &del = " ");
 std::string Explode(const std::vector<std::string>& parts, std::vector<std::string>::const_iterator it, const std::string &del = " ");
 std::string StripWhitespace(const std::string &str);


### PR DESCRIPTION
Fixed all issues with the 'shutdown' command. No more crashing during shutdown.
Added types to all commands and removed the necessity for arguments for the command. You can still display commands by type.
Removed the necessity to specify vnum in redit. If no vnum is declared (or here isn't used) you will modify the current room you occupy. You can still redit rooms remotely.
Added BaseObject::Deserialize() to StaticObject::Deserialize() to load base object information so StaticObjects will be loaded correctly.
Created isnum() and CenterLines() utility functions. They work for now. CenterLines() need to be modified in the future as I get the chance to apply it and see the results.
Added CMDAstat() to the command manager and made a few cosmetic changes to that and CMDZlist to show vnum ranges.