### PR TITLE
Adding setup instructions for mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@
 bin/aspen
 
 #directories
-build/
+build/ 
+data/
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 *.exe
 *.out
 *.app
+bin/aspen
+
+#directories
+build/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ I began work on aspen in late 2009, after trying out a few different engines for
 ## Is Aspen ready-to-use?
 The short answer is probably not. The even longer answer is no; Aspen is currently in development, and as such is not ready for primetime. We still welcome anyone who wishes to use it; if you would like to contribute to the engine, we would greatly appreciate any contributions. Our todo list can     be found [[here|todo]]. You are more than welcome to work  on any individual items, as well as any other section of your choosing.
 
+## Setup Aspen for Development (Mac Sierra v.10.12.6)
+The following steps should get you up and running for development on Aspen
+1. Clone the repo to your local file system: `git clone https://github.com/sorressean/Aspen.git`
+2. Change directories to the cloned repo: `cd aspen`
+3. Make a build directory: `mkdir build`
+4. Change directories to the build directory: `cd build`
+5. Install SSL using homebrew (or other package managers): `brew install openssl`
+6. Create a symbolic link to SSL in your standard includes:
+  * `cd /usr/local/include`
+  * `ln -s ../opt/openssl/include/openssl .`
+7. Generate the makefiles using cmake: `cmake ../`
+8. `make` the project: `make`
+9. Change directories into bin: `cd ../bin/`
+10. Run Aspen: `./aspen`
+
 ## Community
 We do not currently have a mailing list in place for discussions; you can find us on IRC: irc.freenode.net, #aspenmud.
 

--- a/src/objectManager.cpp
+++ b/src/objectManager.cpp
@@ -195,7 +195,7 @@ VNUM ObjectManager::GetFreeRoomVnum(VNUM min, VNUM max, VNUM num)
     int i = min;
     if (num)
         {
-            return (RoomExists(num) ? num : 0);
+            return (!RoomExists(num) ? num : 0);
         }
 
     for (; i <= max; ++i)

--- a/src/zone.cpp
+++ b/src/zone.cpp
@@ -78,15 +78,15 @@ Room* Zone::AddRoom()
     World* world = World::GetPtr();
     ObjectManager* omanager = world->GetObjectManager();
     Room* room = NULL;
-    VNUM freeVNUM = omanager->GetFreeRoomVnum(_vnumrange.min, _vnumrange.max);
+    VNUM num = omanager->GetFreeRoomVnum(_vnumrange.min, _vnumrange.max);
 
-    if (freeVNUM != 0)
+    if (!num)
         {
             throw(std::runtime_error("No more vnums available"));
         }
 
     room = new Room();
-    room->SetOnum(freeVNUM);
+    room->SetOnum(num);
     room->SetZone(this);
     _roomobjs.push_back(room);
     omanager->AddRoom(room);
@@ -97,14 +97,13 @@ Room* Zone::AddRoom(VNUM num)
     World* world = World::GetPtr();
     ObjectManager* omanager = world->GetObjectManager();
     Room* room = NULL;
-    VNUM freeVNUM = omanager->GetFreeRoomVnum(_vnumrange.min, _vnumrange.max, num);
-    if (freeVNUM != 0)
+    if (!omanager->GetFreeRoomVnum(_vnumrange.min, _vnumrange.max, num))
         {
             throw(std::runtime_error("No more vnums available"));
         }
 
     room = new Room();
-    room->SetOnum(freeVNUM);
+    room->SetOnum(num);
     room->SetZone(this);
     _roomobjs.push_back(room);
     omanager->AddRoom(room);
@@ -153,15 +152,15 @@ StaticObject* Zone::AddVirtual()
     World* world = World::GetPtr();
     ObjectManager* omanager = world->GetObjectManager();
     StaticObject* obj = NULL;
-    VNUM freeVNUM = omanager->GetFreeVirtualVnum(_vnumrange.min, _vnumrange.max);
+    VNUM num = omanager->GetFreeVirtualVnum(_vnumrange.min, _vnumrange.max);
 
-    if (freeVNUM != 0)
+    if (!num)
         {
             throw(std::runtime_error("No more vnums available"));
         }
 
     obj = new StaticObject();
-    obj->SetOnum(freeVNUM);
+    obj->SetOnum(num);
     _virtualobjs.push_back(obj);
     omanager->AddVirtual(obj);
     return obj;
@@ -218,15 +217,15 @@ Npc* Zone::AddNpc()
     World* world = World::GetPtr();
     ObjectManager* omanager = world->GetObjectManager();
     Npc* mob = nullptr;
-    VNUM freeVNUM = omanager->GetFreeNpcVnum(_vnumrange.min, _vnumrange.max);
+    VNUM num = omanager->GetFreeNpcVnum(_vnumrange.min, _vnumrange.max);
 
-    if (freeVNUM != 0)
+    if (!num)
         {
             throw(std::runtime_error("No more vnums available"));
         }
 
     mob = new Npc();
-    mob->SetOnum(freeVNUM);
+    mob->SetOnum(num);
     _mobobjs.push_back(mob);
     omanager->AddNpc(mob);
     return mob;

--- a/src/zone.cpp
+++ b/src/zone.cpp
@@ -78,15 +78,15 @@ Room* Zone::AddRoom()
     World* world = World::GetPtr();
     ObjectManager* omanager = world->GetObjectManager();
     Room* room = NULL;
-    VNUM num = omanager->GetFreeRoomVnum(_vnumrange.min, _vnumrange.max);
+    VNUM freeVNUM = omanager->GetFreeRoomVnum(_vnumrange.min, _vnumrange.max);
 
-    if (!num)
+    if (freeVNUM != 0)
         {
             throw(std::runtime_error("No more vnums available"));
         }
 
     room = new Room();
-    room->SetOnum(num);
+    room->SetOnum(freeVNUM);
     room->SetZone(this);
     _roomobjs.push_back(room);
     omanager->AddRoom(room);
@@ -97,13 +97,14 @@ Room* Zone::AddRoom(VNUM num)
     World* world = World::GetPtr();
     ObjectManager* omanager = world->GetObjectManager();
     Room* room = NULL;
-    if (!omanager->GetFreeRoomVnum(_vnumrange.min, _vnumrange.max, num))
+    VNUM freeVNUM = omanager->GetFreeRoomVnum(_vnumrange.min, _vnumrange.max, num);
+    if (freeVNUM != 0)
         {
             throw(std::runtime_error("No more vnums available"));
         }
 
     room = new Room();
-    room->SetOnum(num);
+    room->SetOnum(freeVNUM);
     room->SetZone(this);
     _roomobjs.push_back(room);
     omanager->AddRoom(room);
@@ -152,15 +153,15 @@ StaticObject* Zone::AddVirtual()
     World* world = World::GetPtr();
     ObjectManager* omanager = world->GetObjectManager();
     StaticObject* obj = NULL;
-    VNUM num = omanager->GetFreeVirtualVnum(_vnumrange.min, _vnumrange.max);
+    VNUM freeVNUM = omanager->GetFreeVirtualVnum(_vnumrange.min, _vnumrange.max);
 
-    if (!num)
+    if (freeVNUM != 0)
         {
             throw(std::runtime_error("No more vnums available"));
         }
 
     obj = new StaticObject();
-    obj->SetOnum(num);
+    obj->SetOnum(freeVNUM);
     _virtualobjs.push_back(obj);
     omanager->AddVirtual(obj);
     return obj;
@@ -217,15 +218,15 @@ Npc* Zone::AddNpc()
     World* world = World::GetPtr();
     ObjectManager* omanager = world->GetObjectManager();
     Npc* mob = nullptr;
-    VNUM num = omanager->GetFreeNpcVnum(_vnumrange.min, _vnumrange.max);
+    VNUM freeVNUM = omanager->GetFreeNpcVnum(_vnumrange.min, _vnumrange.max);
 
-    if (!num)
+    if (freeVNUM != 0)
         {
             throw(std::runtime_error("No more vnums available"));
         }
 
     mob = new Npc();
-    mob->SetOnum(num);
+    mob->SetOnum(freeVNUM);
     _mobobjs.push_back(mob);
     omanager->AddNpc(mob);
     return mob;


### PR DESCRIPTION
Adding setup steps for mac sierra, and also updating the .gitignore file to ignore the build directory, as well as explicitly ignore the aspen executable, as -- for some reason -- `*.app` `.*.exe` `*.out` don't seem to cover it on Mac. Strangely the other unix executable files are covered by those rules. 